### PR TITLE
Add support for Django>=1.9 and drop support for older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@
 language: python
 
 python:
+  - "3.6"
+  - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
 #  - "pypy"  TODO: add support for PyPy
 

--- a/django_pgcli/__init__.py
+++ b/django_pgcli/__init__.py
@@ -2,15 +2,18 @@
 
 __author__ = 'Ash Christopher'
 __email__ = 'ash.christopher@gmail.com'
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 
-from django.db.backends.postgresql_psycopg2 import base
-from django.db.backends.postgresql_psycopg2.client import DatabaseClient
+from django.db.backends.postgresql import base
+from django.db.backends.postgresql.client import DatabaseClient
 
 
 class pgcliDatabaseClient(DatabaseClient):
     executable_name = 'pgcli'
+    
+    def runshell(self):
+        pgcliDatabaseClient.runshell_db(self.connection.get_connection_params())
 
-base.__old_database_client = base.DatabaseClient
-base.DatabaseClient = pgcliDatabaseClient
+base.DatabaseWrapper.__old_database_client_class = base.DatabaseClient
+base.DatabaseWrapper.client_class = pgcliDatabaseClient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wheel==0.23.0
 pgcli
-Django>=1.4
+Django>=1.9,<2.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [
 
 setup(
     name='django-pgcli',
-    version='0.0.2',
+    version='0.0.3',
     description="Database runtime for Django that replaces psql with pgcli.",
     long_description=readme + '\n\n' + history,
     author="Ash Christopher",
@@ -48,8 +48,9 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Lanugage :: Python :: 3.6',
     ],
     test_suite='tests',
     tests_require=test_requirements

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'pgcli',
-    'Django>=1.4',
+    'Django>=1.9,<2.0',
 ]
 
 test_requirements = [
     'pgcli',
-    'Django>=1.4',
+    'Django>=1.9,<2.0',
 ]
 
 setup(
@@ -46,7 +46,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_django-pgcli.py
+++ b/tests/test_django-pgcli.py
@@ -10,18 +10,18 @@ class RuntimeTestCase(unittest.TestCase):
     def test_database_client_subclassed(self):
         from django.db.backends.postgresql_psycopg2 import base
 
-        self.assertEqual(base.DatabaseClient, django_pgcli.pgcliDatabaseClient)
+        self.assertEqual(base.DatabaseWrapper.client_class, django_pgcli.pgcliDatabaseClient)
 
     def test_database_client_calls_pgcli_executable(self):
         from django.db.backends.postgresql_psycopg2 import base
           
-        self.assertEqual(base.DatabaseClient.executable_name, 'pgcli')
+        self.assertEqual(base.DatabaseWrapper.client_class.executable_name, 'pgcli')
 
     def test_old_database_client_set_on_base(self):
         from django.db.backends.postgresql_psycopg2 import base
         from django.db.backends.postgresql_psycopg2.client import DatabaseClient
         
-        self.assertEqual(getattr(base, '__old_database_client'), DatabaseClient)
+        self.assertEqual(getattr(base.DatabaseWrapper, '__old_database_client_class'), DatabaseClient)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py27, py33, py34
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34
+envlist = py27, py34, py35, py36
 
 [testenv]
 setenv =


### PR DESCRIPTION
## Notes
Since Django 1.8 is reaching end of life support, I did not add backwards compatibility for versions older than 1.9.

Resolves this [issue](https://github.com/ashchristopher/django-pgcli/issues/4)