### PR TITLE
chore: allow to be used with django 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'pgcli',
-    'Django>=1.9,<2.0',
+    'Django>=1.9',
 ]
 
 test_requirements = [
     'pgcli',
-    'Django>=1.9,<2.0',
+    'Django>=1.9',
 ]
 
 setup(


### PR DESCRIPTION
I can confirm this works with django 2.1.7 - no need for the constraint to be less than 2.0.  Would greatly appreciate publishing an updated version of this library with this constraint removed.